### PR TITLE
[FIX] website: Displays all dependent fields

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -637,6 +637,8 @@ odoo.define('website.s_website_form', function (require) {
                 }
 
                 const formData = new FormData(this.$target[0]);
+                if(['contains', '!contains'].includes(comparator))
+                    return this._compareTo(comparator, formData.getAll(dependencyName).toString(), visibilityCondition, between)
                 const currentValueOfDependency = formData.get(dependencyName);
                 return this._compareTo(comparator, currentValueOfDependency, visibilityCondition, between);
             };

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -147,6 +147,8 @@
                     <!-- Load every existing form input -->
                 </we-select>
                 <we-select data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
+                    <we-button data-select-data-attribute="contains">Contains</we-button>
+                    <we-button data-select-data-attribute="!contains">Doesn't contain</we-button>
                     <we-button data-select-data-attribute="selected">Is equal to</we-button>
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
                 </we-select>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Previously, when we had more than one dependent field on checkboxes, only the first dependent field that met its requirement was displayed. Minor edits were made to go through each instance in the form to see if the requirement for a given dependent field is met and all of the fields for which the requirements are met are displayed.

Current behavior before PR:
When we had more than one dependent field on check-boxes, only the first dependent field that met its requirement was displayed. 

Desired behavior after PR is merged:
All dependent fields for which the requirement is met is displayed.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
