### PR TITLE
[FIX] Website: Shows all the selected visibly dependent field

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2338,7 +2338,9 @@ const VisibilityPageOptionUpdate = options.Class.extend({
         // toggled (otherwise it would be about editing an element which
         // is actually never displayed on the page).
         const widget = this._requestUserValueWidgets(this.showOptionWidgetName)[0];
-        widget.enable();
+        
+         widget.enable();
+   
     },
 
     //--------------------------------------------------------------------------
@@ -2350,6 +2352,8 @@ const VisibilityPageOptionUpdate = options.Class.extend({
      */
     async visibility(previewMode, widgetValue, params) {
         const show = (widgetValue !== 'hidden');
+        
+        
         await new Promise((resolve, reject) => {
             this.trigger_up('action_demand', {
                 actionName: 'toggle_page_option',
@@ -2359,6 +2363,7 @@ const VisibilityPageOptionUpdate = options.Class.extend({
             });
         });
         this.trigger_up('snippet_option_visibility_update', {show: show});
+        
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -625,7 +625,11 @@ odoo.define('website.s_website_form', function (require) {
          */
         _buildVisibilityFunction(fieldEl) {
             const visibilityCondition = fieldEl.dataset.visibilityCondition;
+            
+            
             const dependencyName = fieldEl.dataset.visibilityDependency;
+            
+            console.log(fieldEl.dataset);
             const comparator = fieldEl.dataset.visibilityComparator;
             const between = fieldEl.dataset.visibilityBetween;
             return () => {
@@ -637,8 +641,19 @@ odoo.define('website.s_website_form', function (require) {
                 }
 
                 const formData = new FormData(this.$target[0]);
-                const currentValueOfDependency = formData.get(dependencyName);
-                return this._compareTo(comparator, currentValueOfDependency, visibilityCondition, between);
+               
+                
+                const selected= formData.getAll(dependencyName);
+               
+                if(selected.includes(visibilityCondition))
+                {
+                 
+                return this._compareTo(comparator, visibilityCondition, visibilityCondition, between);
+                }
+                return this._compareTo(comparator, undefined, visibilityCondition, between);
+              
+                
+                
             };
         },
         /**

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -149,6 +149,7 @@
                 <we-select data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
                     <we-button data-select-data-attribute="selected">Is equal to</we-button>
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
+                   
                 </we-select>
                 <we-select data-name="hidden_condition_text_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
                     <!-- str comparator possibilities -->
@@ -187,6 +188,8 @@
                     <!-- file comparator possibilities -->
                     <we-button data-select-data-attribute="fileSet">Is set</we-button>
                     <we-button data-select-data-attribute="!fileSet">Is not set</we-button>
+                 
+                    
                 </we-select>
             </we-row>
             <we-select class="o_we_large" data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityCondition" data-no-preview="true">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: When more than one check boxes were selected only the first visibly reliant field was visible instead of all the fields that are dependent on the different check boxes. 

Current behavior before PR: The field that depends only on the first selection is visible when more than one check boxes are chosen.

Desired behavior after PR is merged: When more than one check boxes are selected all the fields that are dependent for visibility on the check boxes are visible.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
