### PR TITLE
[FIX] website: show all visibly dependent fields

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -637,8 +637,8 @@ odoo.define('website.s_website_form', function (require) {
                 }
 
                 const formData = new FormData(this.$target[0]);
-                const currentValueOfDependency = formData.get(dependencyName);
-                return this._compareTo(comparator, currentValueOfDependency, visibilityCondition, between);
+            	const currentValueOfDependency = ["contains","!contains"].includes(comparator) ? formData.getAll(dependencyName).join() : formData.get(dependencyName);
+		return this._compareTo(comparator, currentValueOfDependency, visibilityCondition, between); 
             };
         },
         /**

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -149,6 +149,8 @@
                 <we-select data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
                     <we-button data-select-data-attribute="selected">Is equal to</we-button>
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
+                    <we-button data-select-data-attribute="contains">Contains</we-button>
+                    <we-button data-select-data-attribute="!contains">Doesn't contain</we-button>
                 </we-select>
                 <we-select data-name="hidden_condition_text_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
                     <!-- str comparator possibilities -->


### PR DESCRIPTION
Description of the issue/feature this PR addresses: When more than one field was visibly dependent on multiple checkboxes, Only the first visibly dependent field was displayed on selecting more than one checkbox.

Current behavior before PR: Only the first visibly dependent field was displayed on selecting more than one checkbox.

Desired behavior after PR is merged: All visibly dependent fields are displayed when more than one checkboxes are selected



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
